### PR TITLE
Fix creation of stop orders

### DIFF
--- a/cbpro/authenticated_client.py
+++ b/cbpro/authenticated_client.py
@@ -173,7 +173,7 @@ class AuthenticatedClient(PublicClient):
         endpoint = '/accounts/{}/holds'.format(account_id)
         return self._send_paginated_message(endpoint, params=kwargs)
 
-    def place_order(self, product_id, side, order_type, **kwargs):
+    def place_order(self, product_id, side, order_type=None, **kwargs):
         """ Place an order.
 
         The three order types (limit, market, and stop) can be placed using this
@@ -183,7 +183,7 @@ class AuthenticatedClient(PublicClient):
         Args:
             product_id (str): Product to order (eg. 'BTC-USD')
             side (str): Order side ('buy' or 'sell)
-            order_type (str): Order type ('limit', 'market', or 'stop')
+            order_type (str): Order type ('limit', or 'market')
             **client_oid (str): Order ID selected by you to identify your order.
                 This should be a UUID, which will be broadcast in the public
                 feed for `received` messages.
@@ -243,7 +243,7 @@ class AuthenticatedClient(PublicClient):
                                  '`IOC` or `FOK`')
 
         # Market and stop order checks
-        if order_type == 'market' or order_type == 'stop':
+        if order_type == 'market' or kwargs.get('stop'):
             if not (kwargs.get('size') is None) ^ (kwargs.get('funds') is None):
                 raise ValueError('Either `size` or `funds` must be specified '
                                  'for market/stop orders (but not both).')
@@ -392,7 +392,7 @@ class AuthenticatedClient(PublicClient):
 
         return self.place_order(**params)
 
-    def place_stop_order(self, product_id, side, price, size=None, funds=None,
+    def place_stop_order(self, product_id, side, stop_type, price, size=None, funds=None,
                          client_oid=None,
                          stp=None,
                          overdraft_enabled=None,
@@ -402,6 +402,9 @@ class AuthenticatedClient(PublicClient):
         Args:
             product_id (str): Product to order (eg. 'BTC-USD')
             side (str): Order side ('buy' or 'sell)
+            stop_type(str): Stop type ('entry' or 'loss')
+                      loss: Triggers when the last trade price changes to a value at or below the stop_price.
+                      entry: Triggers when the last trade price changes to a value at or above the stop_price
             price (Decimal): Desired price at which the stop order triggers.
             size (Optional[Decimal]): Desired amount in crypto. Specify this or
                 `funds`.
@@ -421,10 +424,16 @@ class AuthenticatedClient(PublicClient):
             dict: Order details. See `place_order` for example.
 
         """
+
+        if (side == 'buy' and stop_type == 'loss') or (side == 'sell' and stop_type == 'entry'):
+            raise ValueError(f'Invalid stop order, combination of {side} and {stop_type} is not possible')
+
         params = {'product_id': product_id,
                   'side': side,
                   'price': price,
-                  'order_type': 'stop',
+                  'order_type': None,
+                  'stop': stop_type,
+                  'stop_price': price,
                   'size': size,
                   'funds': funds,
                   'client_oid': client_oid,

--- a/tests/test_authenticated_client.py
+++ b/tests/test_authenticated_client.py
@@ -130,12 +130,20 @@ class TestAuthenticatedClient(object):
         r = client.place_market_order('BTC-USD', 'buy', funds=100000)
         assert type(r) is dict
 
-    def test_place_stop_order(self, client):
+    @pytest.mark.parametrize('stop_type, side', [('entry', 'buy'), ('loss', 'sell')])
+    def test_place_stop_order(self, client, stop_type, side):
         client.cancel_all()
-        r = client.place_stop_order('BTC-USD', 'buy', 1, 0.01)
+        r = client.place_stop_order('BTC-USD', side, stop_type, 100, 0.01)
         assert type(r) is dict
-        assert r['type'] == 'stop'
+        assert r['stop'] == stop_type
+        assert r['stop_price'] == '100.00000000'
+        assert r['type'] == 'limit'
         client.cancel_order(r['id'])
+
+    def test_place_invalid_stop_order(self, client):
+        client.cancel_all()
+        with pytest.raises(ValueError):
+            client.place_stop_order('BTC-USD', 'buy', 'loss', 5.65, 0.01)
 
     def test_cancel_order(self, client):
         r = client.place_limit_order('BTC-USD', 'buy', 4.43, 0.01232)


### PR DESCRIPTION
A 'stop' isn't an actual order type but is actually a special flavour of
a limit order. The 'stop' and 'stop_price' params need to be set.

There are 2 stop types:
1. loss (triggers at or below the stop price) -> this has to be a sell
order to be valid (the Coinbase Pro will respond with an error
otherwise)
2. entry (trigger at or above the stop price) -> has to be a buy

Modified existing and added new test.